### PR TITLE
Edited the rhc command call

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,7 @@ This repository contains modifications to diaspora* for easy deployment.
 - Create the application:
 
   ```bash
-  rhc app create diaspora \
-     ruby-2.0 postgresql-9.2 \
-     'http://cartreflect-claytondev.rhcloud.com/reflect?github=smarterclayton/openshift-redis-cart'
+  rhc app create diaspora ruby-2.0 postgresql-9.2 'http://cartreflect-claytondev.rhcloud.com/reflect?github=smarterclayton/openshift-redis-cart'
 
   ```
 


### PR DESCRIPTION
this command won't work on windows rhc cli:
rhc app create diaspora \
   ruby-2.0 postgresql-9.2 \
   'http://cartreflect-claytondev.rhcloud.com/reflect?github=smarterclayton/openshift-redis-cart'

Just edited it to a single line command to avoid confusion to users.
